### PR TITLE
feat: added support to optionally use bit decompose range checker

### DIFF
--- a/goldilocks/base.go
+++ b/goldilocks/base.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"os"
 
 	"github.com/consensys/gnark-crypto/field/goldilocks"
 	"github.com/consensys/gnark/constraint/solver"
@@ -86,7 +87,16 @@ type Chip struct {
 
 // Creates a new Goldilocks Chip.
 func New(api frontend.API) *Chip {
-	rangeChecker := rangecheck.New(api)
+	use_bit_decomp := os.Getenv("USE_BIT_DECOMPOSITION_RANGE_CHECK")
+
+	var rangeChecker frontend.Rangechecker
+
+	// If USE_BIT_DECOMPOSITION_RANGE_CHECK is not set, then use the std.rangecheck New function
+	if use_bit_decomp == "" {
+		rangeChecker = rangecheck.New(api)
+	} else {
+		rangeChecker = bitDecompChecker{api: api}
+	}
 	return &Chip{api: api, rangeChecker: rangeChecker}
 }
 

--- a/goldilocks/utils.go
+++ b/goldilocks/utils.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/bits"
 )
 
 func StrArrayToBigIntArray(input []string) []big.Int {
@@ -42,4 +43,12 @@ func Uint64ArrayToQuadraticExtensionArray(input [][]uint64) []QuadraticExtension
 		output = append(output, NewQuadraticExtensionVariable(NewVariable(input[i][0]), NewVariable(input[i][1])))
 	}
 	return output
+}
+
+type bitDecompChecker struct {
+	api frontend.API
+}
+
+func (pl bitDecompChecker) Check(v frontend.Variable, nbBits int) {
+	bits.ToBinary(pl.api, v, bits.WithNbDigits(nbBits))
 }


### PR DESCRIPTION
If the env var USE_BIT_DECOMPOSITION_RANGE_CHECK is set to true, then it will use a bit decomposition range checker.  Otherwise, it uses the one that std.rangecheck.New chooses.