### PR TITLE
perf: assertLeadingZeros constraint optimizations

### DIFF
--- a/fri/fri.go
+++ b/fri/fri.go
@@ -75,14 +75,8 @@ func (f *Chip) ToOpenings(c variables.OpeningSet) Openings {
 func (f *Chip) assertLeadingZeros(powWitness gl.Variable, friConfig types.FriConfig) {
 	// Asserts that powWitness'es big-endian bit representation has at least friConfig.ProofOfWorkBits leading zeros.
 	// Note that this is assuming that the Goldilocks field is being used.  Specfically that the
-	// field is 64 bits long
-	maxPowWitness := uint64(math.Pow(2, float64(64-friConfig.ProofOfWorkBits))) - 1
-
-	// TODO:  This does an un-nessary reduce, since powWitness is already range checked to be within GL field.
-	reducedPowWitness := f.gl.Reduce(powWitness)
-
-	// TODO:  Can replace with with std.rangecheck.Check.  Will probably be less contraints.
-	f.api.AssertIsLessOrEqual(reducedPowWitness.Limb, frontend.Variable(maxPowWitness))
+	// field is 64 bits long.
+	f.gl.RangeCheckWithMaxBits(powWitness, 64-friConfig.ProofOfWorkBits)
 }
 
 func (f *Chip) fromOpeningsAndAlpha(

--- a/goldilocks/base.go
+++ b/goldilocks/base.go
@@ -333,6 +333,11 @@ func (p *Chip) RangeCheck(x Variable) {
 	)
 }
 
+// This function will assert that the field element x is less than 2^maxNbBits.
+func (p *Chip) RangeCheckWithMaxBits(x Variable, maxNbBits uint64) {
+	p.rangeChecker.Check(x.Limb, int(maxNbBits))
+}
+
 func (p *Chip) AssertIsEqual(x, y Variable) {
 	p.api.AssertIsEqual(x.Limb, y.Limb)
 }


### PR DESCRIPTION
This PR makes two changes.

1) Removed an un-necessary reduce of `powWitness`.  This value is calculated in the challenger chip by calling [GetChallenge()](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/daad394f734c7641625d1d2b573a13ad266001c2/challenger/challenger.go#L135), which in turn retrieves values from the [challenger output buffer](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/daad394f734c7641625d1d2b573a13ad266001c2/challenger/challenger.go#L89).  The values in the output buffer are filled by the function `duplexing` with the return values from an [invocation of GL Poseidon](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/daad394f734c7641625d1d2b573a13ad266001c2/challenger/challenger.go#L159C20-L159C20).   That [invocation](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/poseidon/goldilocks.go#L30C15-L30C15) will do a GL reduce of the returned values (within the function call chain of [fullRounds](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/poseidon/goldilocks.go#L92) -> [mdsLayer](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/poseidon/goldilocks.go#L203) -> [mdsRowShf](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/poseidon/goldilocks.go#L182C17-L182C17))
2) Replace `AssertIsLessOrEqual` with the gnark range check gadget.  `AssertIsLessOrEqual` does a bit decomposition of the variable under the hood.  Using the range check gadget would reduce number of constraints if the logup/commitment based range checker is used.