### PR TITLE
feat: separate common circuit data deserialization

### DIFF
--- a/types/common_data.go
+++ b/types/common_data.go
@@ -73,6 +73,10 @@ func ReadCommonCircuitData(path string) CommonCircuitData {
 		panic(err)
 	}
 
+	return DeserializeCommonCircuitData(raw)
+}
+
+func DeserializeCommonCircuitData(raw CommonCircuitDataRaw) CommonCircuitData {
 	var commonCircuitData CommonCircuitData
 	commonCircuitData.Config.NumWires = raw.Config.NumWires
 	commonCircuitData.Config.NumRoutedWires = raw.Config.NumRoutedWires


### PR DESCRIPTION
Greeting. I've separated `CommonCircuitData` deserialization from from file reading to make it on par with similar functions such as `ReadVerifierOnlyCircuitData`/`DeserializeVerifierOnlyCircuitData` and `ReadProofWithPublicInputs`/`DeserializeProofWithPublicInputs`

This change is backwards compatible.