### PR TITLE
fix broken circuit serialization

### DIFF
--- a/verifier/util.go
+++ b/verifier/util.go
@@ -9,7 +9,7 @@ import (
 
 type ExampleVerifierCircuit struct {
 	PublicInputs            []gl.Variable                     `gnark:",public"`
-	Proof                   variables.Proof                   `gnark:"-"`
+	Proof                   variables.Proof                   `gnark:",secret"`
 	VerifierOnlyCircuitData variables.VerifierOnlyCircuitData `gnark:"-"`
 
 	// This is configuration for the circuit, it is a constant not a variable


### PR DESCRIPTION
",-" tag will cause proof's wires caps to be serialized into circuit, which means the groth16 cricuit will be binded to one proof.

![image](https://github.com/succinctlabs/gnark-plonky2-verifier/assets/33961674/9bcc2f78-8485-4a83-9c55-cf8ccdf411c0)
