### PR TITLE
 Add comments to EvaluationVars and methods for better clarity, Add documentation for Range and SelectorsInfo structure

### DIFF
--- a/plonk/gates/types.go
+++ b/plonk/gates/types.go
@@ -2,16 +2,20 @@ package gates
 
 const UNUSED_SELECTOR = uint64(^uint32(0)) // max uint32
 
+// Range defines a range with a start and end value.
 type Range struct {
 	start uint64
 	end   uint64
 }
 
+// SelectorsInfo stores information about selectors and their groups.
 type SelectorsInfo struct {
-	selectorIndices []uint64
-	groups          []Range
+	selectorIndices []uint64 // Indices of selectors.
+	groups          []Range  // Ranges defining groups of selectors.
 }
 
+// NewSelectorsInfo creates a new SelectorsInfo instance.
+// It validates that groupStarts and groupEnds have the same length.
 func NewSelectorsInfo(selectorIndices []uint64, groupStarts []uint64, groupEnds []uint64) *SelectorsInfo {
 	if len(groupStarts) != len(groupEnds) {
 		panic("groupStarts and groupEnds must have the same length")
@@ -31,6 +35,7 @@ func NewSelectorsInfo(selectorIndices []uint64, groupStarts []uint64, groupEnds 
 	}
 }
 
+// NumSelectors returns the number of selector groups.
 func (s *SelectorsInfo) NumSelectors() uint64 {
 	return uint64(len(s.groups))
 }

--- a/plonk/gates/vars.go
+++ b/plonk/gates/vars.go
@@ -5,10 +5,11 @@ import (
 	"github.com/succinctlabs/gnark-plonky2-verifier/poseidon"
 )
 
+// EvaluationVars stores variables for gate evaluations in a quadratic extension field.
 type EvaluationVars struct {
-	localConstants   []gl.QuadraticExtensionVariable
-	localWires       []gl.QuadraticExtensionVariable
-	publicInputsHash poseidon.GoldilocksHashOut
+	localConstants   []gl.QuadraticExtensionVariable // Constants local to the gate evaluation
+	localWires       []gl.QuadraticExtensionVariable // Wires representing local variables
+	publicInputsHash poseidon.GoldilocksHashOut      // Hash of the public inputs
 }
 
 func NewEvaluationVars(
@@ -23,10 +24,12 @@ func NewEvaluationVars(
 	}
 }
 
+// RemovePrefix removes the first `numSelectors` elements from localConstants.
 func (e *EvaluationVars) RemovePrefix(numSelectors uint64) {
 	e.localConstants = e.localConstants[numSelectors:]
 }
 
+// GetLocalExtAlgebra retrieves a subrange of local wires as a quadratic extension algebra variable.
 func (e *EvaluationVars) GetLocalExtAlgebra(wireRange Range) gl.QuadraticExtensionAlgebraVariable {
 	// For now, only support degree 2
 	if wireRange.end-wireRange.start != gl.D {


### PR DESCRIPTION
 Add comments to EvaluationVars and methods for better clarit:

- Documented the `EvaluationVars` struct to describe its purpose and fields.
- Added comments for `RemovePrefix` and `GetLocalExtAlgebra` methods explaining their functionality.
- Improved code readability and maintainability by providing clear inline documentation.

Add documentation for Range and SelectorsInfo structure:

- Added comments to the `Range` struct explaining its purpose and fields.
- Documented the `SelectorsInfo` struct with details about selector indices and groups.
- Provided a detailed description for the `NewSelectorsInfo` constructor, including validation logic.
- Added a comment to the `NumSelectors` method to clarify its functionality.
- Improved code readability and maintainability through comprehensive inline documentation.
