### PR TITLE
Port breaking changes from latest plonky2 version

### DIFF
--- a/challenger/challenger.go
+++ b/challenger/challenger.go
@@ -86,6 +86,29 @@ func (c *Chip) ObserveOpenings(openings fri.Openings) {
 	}
 }
 
+func (c *Chip) ObserveFriConfig(
+	config types.FriConfig,
+) {
+	c.ObserveElement(gl.NewVariable(config.RateBits))
+	c.ObserveElement(gl.NewVariable(config.CapHeight))
+	c.ObserveElement(gl.NewVariable(config.ProofOfWorkBits))
+	for i := 0; i < len(config.ReductionStrategy); i++ {
+		c.ObserveElement(gl.NewVariable(config.ReductionStrategy[i]))
+	}
+	c.ObserveElement(gl.NewVariable(config.NumQueryRounds))
+}
+
+func (c *Chip) ObserveFriParams(
+	params types.FriParams,
+) {
+	c.ObserveFriConfig(params.Config)
+	c.ObserveElement(gl.NewVariable(0)) // Hiding, should be always false as hiding is not supported in gnark-plonky2-verifier
+	c.ObserveElement(gl.NewVariable(params.DegreeBits))
+	for i := 0; i < len(params.ReductionArityBits); i++ {
+		c.ObserveElement(gl.NewVariable(params.ReductionArityBits[i]))
+	}
+}
+
 func (c *Chip) GetChallenge() gl.Variable {
 	if len(c.inputBuffer) != 0 || len(c.outputBuffer) == 0 {
 		c.duplexing()

--- a/goldilocks/base.go
+++ b/goldilocks/base.go
@@ -30,13 +30,13 @@ import (
 )
 
 // The multiplicative group generator of the field.
-var MULTIPLICATIVE_GROUP_GENERATOR goldilocks.Element = goldilocks.NewElement(7)
+var MULTIPLICATIVE_GROUP_GENERATOR goldilocks.Element = goldilocks.NewElement(14293326489335486720)
 
 // The two adicity of the field.
 var TWO_ADICITY uint64 = 32
 
 // The power of two generator of the field.
-var POWER_OF_TWO_GENERATOR goldilocks.Element = goldilocks.NewElement(1753635133440165772)
+var POWER_OF_TWO_GENERATOR goldilocks.Element = goldilocks.NewElement(7277203076849721926)
 
 // The modulus of the field.
 var MODULUS *big.Int = emulated.Goldilocks{}.Modulus()

--- a/types/common_data.go
+++ b/types/common_data.go
@@ -86,6 +86,13 @@ func ReadCommonCircuitData(path string) CommonCircuitData {
 	commonCircuitData.Config.FriConfig.RateBits = raw.Config.FriConfig.RateBits
 	commonCircuitData.Config.FriConfig.CapHeight = raw.Config.FriConfig.CapHeight
 	commonCircuitData.Config.FriConfig.ProofOfWorkBits = raw.Config.FriConfig.ProofOfWorkBits
+	// since the only reduction_strategy supported in gnark-plonky2-verifier is
+	// ConstantArityBits, set the first element of the array to 1 (following
+	// https://github.com/0xPolygonZero/plonky2/blob/main/plonky2/src/fri/reduction_strategies.rs#L70).
+	// Ideally this first value set to 1 would already be set by plonky2 serialization of the
+	// CommonCircuitData, but the serializer available in plonky2's implementation does not
+	// include this first value
+	commonCircuitData.Config.FriConfig.ReductionStrategy = append([]uint64{1}, raw.Config.FriConfig.ReductionStrategy.ConstantArityBits...)
 	commonCircuitData.Config.FriConfig.NumQueryRounds = raw.Config.FriConfig.NumQueryRounds
 
 	commonCircuitData.FriParams.DegreeBits = raw.FriParams.DegreeBits
@@ -93,6 +100,9 @@ func ReadCommonCircuitData(path string) CommonCircuitData {
 	commonCircuitData.FriParams.Config.RateBits = raw.FriParams.Config.RateBits
 	commonCircuitData.FriParams.Config.CapHeight = raw.FriParams.Config.CapHeight
 	commonCircuitData.FriParams.Config.ProofOfWorkBits = raw.FriParams.Config.ProofOfWorkBits
+	// set FriParams.ReductionStrategy[0]=1, for the same reason as in
+	// FriConfig.ReductionStrategy few lines above
+	commonCircuitData.FriParams.Config.ReductionStrategy = append([]uint64{1}, raw.FriParams.Config.ReductionStrategy.ConstantArityBits...)
 	commonCircuitData.FriParams.Config.NumQueryRounds = raw.FriParams.Config.NumQueryRounds
 	commonCircuitData.FriParams.ReductionArityBits = raw.FriParams.ReductionArityBits
 

--- a/types/types.go
+++ b/types/types.go
@@ -5,13 +5,11 @@ import (
 )
 
 type FriConfig struct {
-	RateBits        uint64
-	CapHeight       uint64
-	ProofOfWorkBits uint64
-	NumQueryRounds  uint64
-	// Note that we do not need `reduction_strategy` of type FriReductionStrategy as the plonky2 FriConfig has.
-	// reduction_strategy is only used for computing `reduction_arity_bits`, which is serialized in the
-	// CommonCircuitData.
+	RateBits          uint64
+	CapHeight         uint64
+	ProofOfWorkBits   uint64
+	ReductionStrategy []uint64 // only ConstantArityBits is supported
+	NumQueryRounds    uint64
 }
 
 func (fc *FriConfig) Rate() float64 {

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -53,6 +53,7 @@ func (c *VerifierChip) GetChallenges(
 
 	var circuitDigest = verifierData.CircuitDigest
 
+	challenger.ObserveFriParams(c.commonData.FriParams)
 	challenger.ObserveBN254Hash(circuitDigest)
 	challenger.ObserveHash(publicInputsHash)
 	challenger.ObserveCap(proof.WiresCap)


### PR DESCRIPTION
This PR updates the repo to be compatible with the latest plonky2 version (as of date of August 2025).

The changes done are updating the `gnark-plonky2-verifier` to the specific plonky2's breaking changes that were done since last `gnark-plonky2-verifier` update:
- https://github.com/0xPolygonZero/plonky2/pull/1579
- https://github.com/0xPolygonZero/plonky2/pull/1678


Notes:
- First of all, thank you very much for creating this repository, it's a great resource for the community!
- The [testdata](https://github.com/succinctlabs/gnark-plonky2-verifier/tree/main/testdata) directory becomes now outdated, since it was generated with a plonky2 version about 2 years old from now; I can generate new testdata with the latest plonky2 version of some new circuits, but if you prefer we can generate it for the same circuits that you used for the old version (in that case I would need to know where to find those circuits). In any case, I've tested this PR with multiple various plonky2 circuits and everything seems to work fine (including Solidity verification). Maybe we could even add the code to generate the testdata in the repo, so that it does not depend on hardcoded testdata.
- plonky2 is now [officially unmaintained](https://github.com/0xPolygonZero/plonky2/commit/5d9da5a65bbcba2c66eb29c035090eb2e9ccb05f), and probably this current repo (`gnark-plonky2-verifier`) is not actively maintained, so I if this PR is not merged it would be totally understandable; but still opening this PR in case other people want to use it to generate gnark proofs of plonky2 proofs, so that they can find this PR and avoid spending time figuring out why it does not verify proofs from the current plonky2 version